### PR TITLE
Fix issue of Shaman's Ascendance not tracking

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -53,6 +53,8 @@ globals = {
     "OmniBar_CooldownFinish",
     "OmniBar_StartCooldown",
     "OmniBar_Test",
+    "OmniBar_IsUnitEnabled",
+    "OmniBar_ToggleUnit",
     "InterfaceOptionsFrame_OpenToCategory",
 
     -- framexml misc

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - /home/travis/.luarocks/bin/luacheck . -q
 
 script:
-  - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 1.13.5
+  - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash -s -- -g 1.13.6
   - curl -s https://raw.githubusercontent.com/BigWigsMods/packager/master/release.sh | bash
 
 branches:

--- a/OmniBar.lua
+++ b/OmniBar.lua
@@ -467,15 +467,12 @@ function OmniBar_OnEvent(self, event, ...)
 						for j = 1, #resets[spellID] do
 							if resets[spellID][j].spell == self.active[i].spellID then
 								local startTime, startDuration = self.active[i].cooldown:GetCooldownTimes()
-								print(GetTime() - startTime)
 								local currCD = (startDuration - (GetTime()*1000 - startTime))/1000
-								print(currCD)
 								local newDuration = currCD - resets[spellID][j].amount
 								if (newDuration <= 0) then									
 									self.active[i].cooldown:Hide()
 									OmniBar_CooldownFinish(self.active[i].cooldown, true)
 								else
-									print(newDuration)
 									self.active[i].cooldown:SetCooldown(GetTime(), newDuration)
 									self.active[i].cooldown.finish = GetTime() + newDuration
 								end

--- a/OmniBar.lua
+++ b/OmniBar.lua
@@ -469,7 +469,7 @@ function OmniBar_OnEvent(self, event, ...)
 								local startTime, startDuration = self.active[i].cooldown:GetCooldownTimes()
 								local currCD = (startDuration - (GetTime()*1000 - startTime))/1000
 								local newDuration = currCD - resets[spellID][j].amount
-								if (newDuration <= 0) then									
+								if (newDuration <= 0) then
 									self.active[i].cooldown:Hide()
 									OmniBar_CooldownFinish(self.active[i].cooldown, true)
 								else
@@ -716,7 +716,7 @@ function OmniBar_AddIcon(self, spellID, sourceGUID, sourceName, init, test, spec
 	-- Check for parent spellID
 	local originalSpellID = spellID
 	if cooldowns[spellID].parent then spellID = cooldowns[spellID].parent end
-	unitID = 0
+	local unitID = 0
 	if sourceGUID ~= nil then
 		if UnitGUID("arena1") == sourceGUID or sourceGUID == 1 then
 			unitID = 1

--- a/OmniBar.lua
+++ b/OmniBar.lua
@@ -27,6 +27,12 @@ local order = {
 local resets = addon.Resets
 
 -- Defaults
+local units = {
+	enabled0 = {default = true},
+	enabled1 = {default = true},
+	enabled2 = {default = true},
+	enabled3 = {default = true},
+}
 local defaults = {
 	size                 = 40,
 	columns              = 8,
@@ -459,9 +465,20 @@ function OmniBar_OnEvent(self, event, ...)
 					if self.active[i] and self.active[i].spellID and self.active[i].sourceGUID and self.active[i].sourceGUID == sourceGUID and self.active[i].cooldown:IsVisible() then
 						-- cooldown belongs to this source
 						for j = 1, #resets[spellID] do
-							if resets[spellID][j] == self.active[i].spellID then
-								self.active[i].cooldown:Hide()
-								OmniBar_CooldownFinish(self.active[i].cooldown, true)
+							if resets[spellID][j].spell == self.active[i].spellID then
+								local startTime, startDuration = self.active[i].cooldown:GetCooldownTimes()
+								print(GetTime() - startTime)
+								local currCD = (startDuration - (GetTime()*1000 - startTime))/1000
+								print(currCD)
+								local newDuration = currCD - resets[spellID][j].amount
+								if (newDuration <= 0) then									
+									self.active[i].cooldown:Hide()
+									OmniBar_CooldownFinish(self.active[i].cooldown, true)
+								else
+									print(newDuration)
+									self.active[i].cooldown:SetCooldown(GetTime(), newDuration)
+									self.active[i].cooldown.finish = GetTime() + newDuration
+								end
 								return
 							end
 						end
@@ -595,6 +612,20 @@ function OmniBar_IsSpellEnabled(self, spellID)
 		return true
 	end
 end
+function OmniBar_IsUnitEnabled(self, unitID)
+	if not unitID then return end
+	-- Check for an explicit rule
+	local key = "enabled"..unitID
+	if type(self.settings[key]) == "boolean" then
+		if self.settings[key] then
+			return true
+		end
+	elseif not self.settings.noDefault and units[key].default then
+		-- Not user-set, but a default cooldown
+		return true
+	end
+	return false
+end
 
 function OmniBar_Center(self)
 	local parentWidth = UIParent:GetWidth()
@@ -688,8 +719,21 @@ function OmniBar_AddIcon(self, spellID, sourceGUID, sourceName, init, test, spec
 	-- Check for parent spellID
 	local originalSpellID = spellID
 	if cooldowns[spellID].parent then spellID = cooldowns[spellID].parent end
+	unitID = 0
+	if sourceGUID ~= nil then
+		if UnitGUID("arena1") == sourceGUID or sourceGUID == 1 then
+			unitID = 1
+			else if UnitGUID("arena2") == sourceGUID or sourceGUID == 2 then
+				unitID = 2
+				else if UnitGUID("arena3") == sourceGUID or sourceGUID == 3 then
+					unitID = 3
+				end
+			end
+		end
+	end
 
 	if not OmniBar_IsSpellEnabled(self, spellID) then return end
+	if not test then if not OmniBar_IsUnitEnabled(self, unitID) then return end end
 
 	local icon, duplicate
 
@@ -940,7 +984,8 @@ function OmniBar_Position(self)
 	end
 	OmniBar_ShowAnchor(self)
 end
-
+function OmniBar_ToggleUnit(self, unitID)
+end
 function OmniBar:Test()
 	for key,_ in pairs(self.db.profile.bars) do
 		OmniBar_Test(_G[key])

--- a/OmniBar.toc
+++ b/OmniBar.toc
@@ -1,8 +1,8 @@
 #@retail@
-## Interface: 90001
+## Interface: 90002
 #@end-retail@
 #@non-retail@
-# ## Interface: 11305
+# ## Interface: 11306
 #@end-non-retail@
 ## Title: OmniBar
 ## Notes: Tracks enemy cooldowns

--- a/Options.lua
+++ b/Options.lua
@@ -31,6 +31,10 @@ local function IsSpellEnabled(info)
 	local key = info[2]
 	return OmniBar_IsSpellEnabled(_G[key], OmniBar.options.args.bars.args[key].args.spells.args[info[4]].args[info[5]].arg)
 end
+local function IsUnitEnabled(info)
+	local key = info[2]
+	return OmniBar_IsUnitEnabled(_G[key], OmniBar.options.args.bars.args[key].args.units.args[info[4]].args[info[5]].arg)
+end
 
 StaticPopupDialogs["OMNIBAR_DELETE"] = {
 	text = DELETE.." \"%s\"",
@@ -49,7 +53,11 @@ function OmniBar:ToggleLock(button)
 	OmniBar_Position(_G[button.arg])
 	self.options.args.bars.args[button.arg].args.lock.name = self.db.profile.bars[button.arg].locked and L["Unlock"] or L["Lock"]
 end
-
+local function GetBars(key)
+	local bars = {}
+	for k in pairs(OmniBar.db.profile.bars) do if k ~= key then bars[k] = OmniBar.db.profile.bars[k].name end end
+	return bars
+end
 local function GetSpells()
 	local spells = {
 		uncheck = {
@@ -83,6 +91,28 @@ local function GetSpells()
 				OmniBar:Refresh(true)
 			end,
 			order = 2,
+		},
+		copy = {
+			name = "Copy From: ",
+			desc = "Copys all enabled spells from the selected OmniBar",
+			type = "select",
+			width = "normal",
+			values = GetBars(k),
+			set = 	function(info, state)
+						local key = info[#info-2]
+						OmniBar.db.profile.bars[key].noDefault = true
+						for spellID, spell in pairs(OmniBar.cooldowns) do
+							if OmniBar.db.profile.bars[key]["spell"..spellID]~=nil then
+								OmniBar.db.profile.bars[key]["spell"..spellID] = nil
+							end
+							if OmniBar_IsSpellEnabled(_G[state], spellID) then
+								OmniBar_CreateIcon(_G[key])
+								OmniBar.db.profile.bars[key]["spell"..spellID] = true
+							end
+						end
+						OmniBar:Refresh(true)
+					end,
+			order = 3,
 		},
 	}
 	local descriptions = {}
@@ -131,6 +161,41 @@ local function GetSpells()
 		end
 	end
 	return spells
+end
+
+local function GetUnits()
+	local units = {
+		AllEnemies = {
+			name = "All Enemies",
+			type = "group",
+			args = {
+				enabled0 = {
+					name = "Enable All Enemies",
+					type = "toggle",
+					get = IsUnitEnabled,
+					width = "full",
+					arg = 0,
+					desc = "Enable All Enemies",
+				} },
+		}
+	}
+	for i = 1, 3 do
+		units["arena"..i] = {
+			name = "arena"..i,
+			type = "group",
+			args = {},
+		}
+		units["arena"..i].args["enabled"..i] = {
+					name = "Enable Arena "..i,
+					type = "toggle",
+					get = IsUnitEnabled,
+					width = "full",
+					arg = i,
+					desc = "Track Cooldowns for Arena "..i,
+				}
+	end
+
+	return units
 end
 
 function OmniBar:AddBarToOptions(key, refresh)
@@ -558,6 +623,19 @@ function OmniBar:AddBarToOptions(key, refresh)
 					local option = info[#info]
 					self.db.profile.bars[key][option] = state
 					OmniBar_CreateIcon(_G[key])
+					self:Refresh(true)
+				end,
+			},
+						units = {
+				name = "Units",
+				type = "group",
+				order = 14,
+				arg = key,
+				args = GetUnits(),
+				set = function(info, state)
+					local option = info[#info]
+					self.db.profile.bars[key][option] = state
+					OmniBar_ToggleUnit(_G[key], option)
 					self:Refresh(true)
 				end,
 			},

--- a/Options.lua
+++ b/Options.lua
@@ -97,7 +97,7 @@ local function GetSpells()
 			desc = "Copys all enabled spells from the selected OmniBar",
 			type = "select",
 			width = "normal",
-			values = GetBars(k),
+			values = GetBars(),
 			set = 	function(info, state)
 						local key = info[#info-2]
 						OmniBar.db.profile.bars[key].noDefault = true

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ https://github.com/jordonwow/omnibar/issues
 **Submit a pull request:**
 https://github.com/jordonwow/omnibar/pulls
 
+## v10.11
+* Jax Updates
+* CD Reset Tracking
+* Unit specific bars
+* Copy spells from existing bar
+
 ## v10.10
 * Fix Premonition
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ https://github.com/jordonwow/omnibar/issues
 **Submit a pull request:**
 https://github.com/jordonwow/omnibar/pulls
 
+## v10.13
+* Minor bug fix
+
 ## v10.12
 * Updated for hotfixes
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ https://github.com/jordonwow/omnibar/issues
 **Submit a pull request:**
 https://github.com/jordonwow/omnibar/pulls
 
+## v10.12
+* Updated for hotfixes
+
 ## v10.11
 * Jax Updates
 * CD Reset Tracking

--- a/Retail.lua
+++ b/Retail.lua
@@ -6,7 +6,8 @@ addon.Resets = {
     --[[ Grimoire: Felhunter
          - Spell Lock
       ]]
-    [111897] = { 119910 },
+    [111897] = { {spell = 119910, amount = 24} },
+    [133] = { {spell = 190319, amount = 5} }
 }
 
 addon.Cooldowns = {
@@ -391,9 +392,9 @@ addon.Cooldowns = {
     [108271] = { duration = 90, class = "SHAMAN" }, -- Astral Shift
         [210918] = { parent = 108271, duration = 45 }, -- Ethereal Form
     [114049] = { duration = 180, class = "SHAMAN" }, -- Ascendance
-        [114050] = { parent = 114050 }, -- Ascendance (Elemental)
-        [114051] = { parent = 114050 }, -- Ascendance (Enhancement)
-        [114052] = { parent = 114050 }, -- Ascendance (Restoration)
+        [114050] = { parent = 114049 }, -- Ascendance (Elemental)
+        [114051] = { parent = 114049 }, -- Ascendance (Enhancement)
+        [114052] = { parent = 114049 }, -- Ascendance (Restoration)
     [192058] = { duration = 60, class = "SHAMAN" }, -- Capacitor
     [192077] = { duration = 120, class = "SHAMAN" }, -- Wind Rush Totem
     [204330] = { duration = 45, class = "SHAMAN" }, -- Skyfury Totem
@@ -523,7 +524,7 @@ addon.Cooldowns = {
         [108853] = { duration = 12, class = "MAGE", specID = { 63 }, charges = 2 }, -- Fire Blast
         [153561] = { duration = 45, class = "MAGE", specID = { 63 } }, -- Meteor
         [157981] = { duration = 25, class = "MAGE", specID = { 63 } }, -- Blast Wave
-        [190319] = { duration = 115, class = "MAGE", specID = { 63 } }, -- Combustion
+        [190319] = { duration = 120, class = "MAGE", specID = { 63 } }, -- Combustion
         [194466] = { duration = 45, class = "MAGE", specID = { 63 }, charges = 3 }, -- Phoenix's Flames
         [205029] = { duration = 45, class = "MAGE", specID = { 63 } }, -- Flame On
 

--- a/Retail.lua
+++ b/Retail.lua
@@ -7,7 +7,7 @@ addon.Resets = {
          - Spell Lock
       ]]
     [111897] = { {spell = 119910, amount = 24} },
-    [133] = { {spell = 190319, amount = 5} }
+    [133] = { {spell = 190319, amount = 3} }
 }
 
 addon.Cooldowns = {


### PR DESCRIPTION
I noticed that the tracking of Shaman's **Ascendance** was not triggering when spell was actually thrown.

Fortunately, the fix is very simple: the parent spell id was wrongly set inside **Retail.lua** file. This change was tested and it works.