### PR TITLE
Filter Creature Spell which cooldown is unnormal

### DIFF
--- a/OmniBar.lua
+++ b/OmniBar.lua
@@ -713,6 +713,8 @@ end
 
 
 function OmniBar_AddIcon(self, spellID, sourceGUID, sourceName, init, test, specID)
+	-- Filter the spells which cast by Creatures.
+	if (strsplit("-", sourceGUID)) == "Creature" then return end
 	-- Check for parent spellID
 	local originalSpellID = spellID
 	if cooldowns[spellID].parent then spellID = cooldowns[spellID].parent end


### PR DESCRIPTION
I think players not want know the hostile Creature's spell and it's cooldown, it's meanless and make them confusion. So I add a filter. Is that OK?