### PR TITLE
Update some cooldowns for retail shadowlands

### DIFF
--- a/Retail.lua
+++ b/Retail.lua
@@ -386,8 +386,8 @@ addon.Cooldowns = {
 
     -- Shaman
 
-    [2825] = { duration = 60, class = "SHAMAN" }, -- Bloodlust
-        [32182] = { parent = 2825 }, -- Heroism
+    [204361] = { duration = 60, class = "SHAMAN" }, -- Bloodlust
+        [204362] = { parent = 2825 }, -- Heroism
     [20608] = { duration = 1800, class = "SHAMAN" }, -- Reincarnation
     [51485] = { duration = 30, class = "SHAMAN" }, -- Earthgrab Totem
     [51514] = { duration = { default = 30, [264] = 10 }, class = "SHAMAN" }, -- Hex

--- a/Retail.lua
+++ b/Retail.lua
@@ -91,7 +91,7 @@ addon.Cooldowns = {
         [196555] = { parent = 212800, duration = 90 }, -- Netherwalk
     [214743] = { duration = 60, class = "DEMONHUNTER" }, -- Soul Carver
         [207407] = { parent = 214743 }, -- Soul Carver (Vengeance)
-    [221527] = { duration = 45, class = "DEMONHUNTER" }, -- Imprison
+    [221527] = { duration = 60, class = "DEMONHUNTER" }, -- Imprison
     [323639] = { duration = 90, class = "DEMONHUNTER" }, -- The Hunt
 
         -- Havoc
@@ -115,7 +115,7 @@ addon.Cooldowns = {
     -- Priest
 
     [586] = { duration = 30, class = "PRIEST" }, -- Fade
-        [213602] = { parent = 586 }, -- Greater Fade
+        [213602] = { parent = 586, duration = 45 }, -- Greater Fade
     [32375] = { duration = 45, class = "PRIEST" }, -- Mass Dispel
 	[323673] = { duration = 45, class = "PRIEST" }, -- Mindgames
     [316262] = { duration = 90, class = "PRIEST" }, -- Thoughtsteal
@@ -135,6 +135,7 @@ addon.Cooldowns = {
         [197862] = { duration = 60, class = "PRIEST", specID = { 256 } }, -- Archangel
         [197871] = { duration = 60, class = "PRIEST", specID = { 256 } }, -- Dark Archangel
         [204263] = { duration = 45, class = "PRIEST", specID = { 256, 257 } }, -- Shining Force
+        [527] = { duration = 8, class = "PRIEST", specID = { 256, 257 }, charges = 2 }, -- Purify
 
         -- Holy
 
@@ -147,6 +148,7 @@ addon.Cooldowns = {
         [200183] = { duration = 120, class = "PRIEST", specID = { 257 } }, -- Apotheosis
         [213610] = { duration = 30, class = "PRIEST", specID = { 257 } }, -- Holy Ward
         [215769] = { duration = 300, class = "PRIEST", specID = { 257 } }, -- Spirit of Redemption
+        [88625] = { duration = 60, class = "PRIEST", specID = { 257 } }, -- Holy Word: Chastise
 
         -- Shadow
 
@@ -176,6 +178,7 @@ addon.Cooldowns = {
         [231895] = { parent = 31884 }, -- Crusade
     [115750] = { duration = 90, class = "PALADIN" }, -- Blinding Light
 	[304971] = { duration = 60, class = "PALADIN" }, -- Divine Toll
+    [316958] = { duration = 240, class = "PALADIN" }, -- Ashen Hollow
 
         -- Holy
 
@@ -187,6 +190,7 @@ addon.Cooldowns = {
         [200652] = { duration = 90, class = "PALADIN", specID = { 65 } }, -- Tyr's Deliverance
         [210294] = { duration = 25, class = "PALADIN", specID = { 65 } }, -- Divine Favor
         [214202] = { duration = 30, class = "PALADIN", specID = { 65 }, charges = 2 }, -- Rule of Law
+        [4987] = { duration = 8, class = "PALADIN", specID = { 65 } }, -- Cleanse
 
         -- Protection
 
@@ -195,10 +199,10 @@ addon.Cooldowns = {
         [86659] = { duration = 300, class = "PALADIN", specID = { 66 } }, -- Guardian of Ancient Kings
             [228049] = { parent = 86659 }, -- Guardian of the Forgotten Queen
         [96231] = { default = true, duration = 15, class = "PALADIN", specID = { 66, 70 } }, -- Rebuke
-        [152262] = { duration = 30, class = "PALADIN", specID = { 66 } }, -- Seraphim
+        [152262] = { duration = 45, class = "PALADIN", specID = { 66 } }, -- Seraphim
         [190784] = { duration = 45, class = "PALADIN", specID = { 66 } }, -- Divine Steed
         [209202] = { duration = 60, class = "PALADIN", specID = { 66 } }, -- Eye of Tyr
-        [215652] = { duration = 25, class = "PALADIN", specID = { 66 } }, -- Shield of Virtue
+        [215652] = { duration = 45, class = "PALADIN", specID = { 66 } }, -- Shield of Virtue
 
         -- Retribution
 
@@ -269,6 +273,7 @@ addon.Cooldowns = {
         [203651] = { duration = 45, class = "DRUID", specID = { 105} }, -- Overgrowth
         [305497] = { duration = 45, class = "DRUID", specID = { 102, 103, 105} }, -- Thorns
         [208253] = { duration = 90, class = "DRUID", specID = { 105} }, -- Essence of G'Hanir
+        [88423] = { duration = 8, class = "DRUID", specID = { 105 } }, -- Nature's Cure
 
     -- Warrior
 
@@ -286,6 +291,7 @@ addon.Cooldowns = {
     [107574] = { duration = 90, class = "WARRIOR" }, -- Avatar
     [236077] = { duration = 45, class = "WARRIOR" }, -- Disarm
         [236236] = { parent = 236077 }, -- Disarm (Protection)
+    [307865] = { duration = 60, class = "WARRIOR" }, -- Spear of Bastion
 
         -- Arms
 
@@ -300,6 +306,7 @@ addon.Cooldowns = {
             [46924] = { parent = 227847 }, -- Bladestorm (Fury)
             [152277] = { parent = 227847 }, -- Ravager
         [236273] = { duration = 60 , class = "WARRIOR", specID = { 71 } }, -- Duel
+        [236320] = { duration = 90, class = "WARRIOR", specID = { 71 } }, -- War Banner
 
         -- Fury
 
@@ -405,6 +412,7 @@ addon.Cooldowns = {
     [204330] = { duration = 45, class = "SHAMAN" }, -- Skyfury Totem
     [204331] = { duration = 45, class = "SHAMAN" }, -- Counterstrike Totem
     [204332] = { duration = 30, class = "SHAMAN" }, -- Windfury Totem
+    [8143] = { duration = 60, class = "SHAMAN" }, -- Tremor Totem
 
         -- Elemental
 
@@ -427,7 +435,7 @@ addon.Cooldowns = {
         [197214] = { duration = 40, class = "SHAMAN", specID = { 263 } }, -- Sundering
         [201898] = { duration = 45, class = "SHAMAN", specID = { 263 } }, -- Windsong
         [204366] = { duration = 45, class = "SHAMAN", specID = { 263 } }, -- Thundercharge
-        [204945] = { duration = 60, class = "SHAMAN", specID = { 263 } }, -- Doom Winds
+        [335903] = { duration = 60, class = "SHAMAN", specID = { 263 } }, -- Doom Winds
 		[320674] = { duration = 90, class = "SHAMAN", specID = { 263 } }, -- Chain Harvest
 
         -- Restoration
@@ -442,6 +450,7 @@ addon.Cooldowns = {
         [204336] = { duration = 30, class = "SHAMAN", specID = { 264 } }, -- Grounding Totem
         [207399] = { duration = 300, class = "SHAMAN", specID = { 264 } }, -- Ancestral Protection Totem
         [207778] = { duration = 45, class = "SHAMAN", specID = { 264 } }, -- Gift of the Queen
+        [77130] = { duration = 8, class = "SHAMAN", specID = { 264 } }, -- Purify Spirit
 
     -- Hunter
 
@@ -454,7 +463,7 @@ addon.Cooldowns = {
         [206505] = { parent = 131894 }, -- A Murder of Crows (Survival)
     [186257] = { duration = { default = 180, [253] = 120, [255] = 144 }, class = "HUNTER" }, -- Aspect of the Cheetah
     [186265] = { duration = { default = 180, [255] = 144 }, class = "HUNTER" }, -- Aspect of the Turtle
-    [187650] = { duration = { default = 30, [255] = 20 }, class = "HUNTER" }, -- Freezing Trap
+    [187650] = { duration = 25, class = "HUNTER" }, -- Freezing Trap
     [202914] = { duration = 60, class = "HUNTER" }, -- Spider Sting
     [209997] = { duration = 30, class = "HUNTER" }, -- Play Dead
 
@@ -605,6 +614,7 @@ addon.Cooldowns = {
     [122278] = { duration = 120, class = "MONK" }, -- Dampen Harm
     [122783] = { duration = 120, class = "MONK" }, -- Diffuse Magic
     [123986] = { duration = 30, class = "MONK" }, -- Chi Burst
+    [310454] = { duration = 120, class = "MONK" }, -- Weapons of Order
 
         -- Brewmaster
 
@@ -638,5 +648,6 @@ addon.Cooldowns = {
         [116849] = { duration = 120, class = "MONK", specID = { 270 } }, -- Life Cocoon
         [197908] = { duration = 90, class = "MONK", specID = { 270 } }, -- Mana Tea
         [198898] = { duration = 30, class = "MONK", specID = { 270 } }, -- Song of Chi-Ji
+        [115450] = { duration = 8, class = "MONK", specID = { 270 } }, -- Detox
 
 }


### PR DESCRIPTION
DH:
- Imprison with spell ID 221527 (improved version with PVP talent) is 60s cooldown

Priest:
- Greater Fade is 45s cooldown
- Add Purify for Holy/Disc
- Add Chastise for Holy

Paladin:
- Add Ashen Hollow
- Add Cleanse for Holy
- Fix Seraphim and Shield of Virtue cooldown, both should be 45s

Druid:
- Add Nature's Cure for Restoration

Warrior:
- Add Spear of Bastion
- Add War Banner

Shaman:
- Add Tremor Totem
- Fix the Doom Winds spell ID (the one from Enhancement legendary)
- Fix Enhancement Bloodlust/Heroism spell ID (the one usable in arena)
- Add Purify Spirit for Restoration

Hunter:
- Fix Freezing Trap cooldown, should be 25s

Monk:
- Add Weapons of Order
- Add Detox for Mistweaver