### PR TITLE
Small changes and spell additions to Mainline (Retail)

### DIFF
--- a/OmniBar_Mainline.lua
+++ b/OmniBar_Mainline.lua
@@ -34,6 +34,7 @@ addon.Cooldowns = {
     [48743] = {duration = 120, class = "DEATHKNIGHT"}, -- Death Pact
     [43265] = {duration = 30, class = "DEATHKNIGHT", charges = 2}, -- Death and Decay
 		[152280] = {parent = 43265, duration = 20, specID = {252}}, -- Defile
+    [49039] = {duration = 120, class = "DEATHKNIGHT"}, -- Lichborne
 
 		-- Blood
 
@@ -89,6 +90,7 @@ addon.Cooldowns = {
     [370965] = {duration = 90, class = "DEMONHUNTER"}, -- The Hunt
     [204596] = {duration = 30, class = "DEMONHUNTER"}, -- Sigil of Flame
     [207684] = {duration = 90, class = "DEMONHUNTER"}, -- Sigil of Misery
+    [278326] = {duration = 10, class = "DEMONHUNTER"}, -- Consume Magic
 
 		-- Havoc
 
@@ -110,7 +112,7 @@ addon.Cooldowns = {
 
     -- Priest
 
-    [586] = {duration = 30, class = "PRIEST"}, -- Fade
+    [586] = {duration = 20, class = "PRIEST"}, -- Fade
     [32375] = {duration = 45, class = "PRIEST"}, -- Mass Dispel
     [375901] = {duration = 45, class = "PRIEST"}, -- Mindgames
     [316262] = {duration = 90, class = "PRIEST"}, -- Thoughtsteal
@@ -354,7 +356,7 @@ addon.Cooldowns = {
     [353294] = {duration = 60, class = "WARLOCK"}, -- Shadow Rift
     [48020] = {duration = 30, class = "WARLOCK"}, -- Demonic Circle Teleport
     [333889] = {duration = 120, class = "WARLOCK"}, -- Fel Domination
-    [328774] = {duration = 30, class = "WARLOCK"}, -- Amplify Curse
+    [328774] = {duration = 20, class = "WARLOCK"}, -- Amplify Curse
     [212623] = {duration = 15, class = "WARLOCK"}, -- Singe Magic
 		[137178] = {parent = 212623}, -- Singe Magic
 		[89808] = {parent = 212623}, -- Singe Magic
@@ -395,6 +397,7 @@ addon.Cooldowns = {
 		[196447] = {duration = 25, class = "WARLOCK", specID = {267}}, -- Channel Demonfire
 		[387976] = {duration = 45, class = "WARLOCK", specID = {267}, charges = 3}, -- Dimensional Rift
 		[1122] = {duration = 180, class = "WARLOCK", specID = {267}}, -- Summon Infernal
+		[6353] = {duration = 45, class = "WARLOCK", specID = {267}}, -- Soul Fire
 
     -- Shaman
 
@@ -649,7 +652,7 @@ addon.Cooldowns = {
     [386276] = {duration = 60, class = "MONK"}, -- Bonedust Brew
     [115203] = {duration = 360, class = "MONK"}, -- Fortifying Brew
     [116705] = {default = true, duration = 15, class = "MONK"}, -- Spear Hand Strike
-    [202370] = {duration = 60, class = "MONK"}, -- Mighty Ox Kick
+    [202370] = {duration = 30, class = "MONK"}, -- Mighty Ox Kick
     [322109] = {duration = 90, class = "MONK"}, -- Touch of Death
     [233759] = {duration = 45, class = "MONK"}, -- Grapple Weapon
 

--- a/OmniBar_Mainline.lua
+++ b/OmniBar_Mainline.lua
@@ -531,6 +531,7 @@ addon.Cooldowns = {
 		[212640] = {duration = 25, class = "HUNTER", specID = {255}}, -- Mending Bandage
 		[360952] = {duration = 120, class = "HUNTER", specID = {255}}, -- Coordinated Assault
 		[360966] = {duration = 90, class = "HUNTER", specID = {255}}, -- Spearhead
+		[269751] = {duration = 30, class = "HUNTER", specID = {255}}, -- Flanking Strike
 		[212638] = {duration = 25, class = "HUNTER", specID = {255}}, -- Tracker's Net
 
     -- Mage

--- a/OmniBar_Mainline.lua
+++ b/OmniBar_Mainline.lua
@@ -176,10 +176,9 @@ addon.Cooldowns = {
 		[199448] = {parent = 6940, duration = 120}, -- Ultimate Sacrifice
     [20066] = {duration = 15, class = "PALADIN"}, -- Repentance
     [31884] = {duration = 120, class = "PALADIN"}, -- Avenging Wrath
-		[31842] = {parent = 31884}, -- Avenging Wrath (Holy)
 		[216331] = {parent = 31884}, -- Avenging Crusader
-		[224668] = {parent = 31884}, -- Crusade
 		[231895] = {parent = 31884}, -- Crusade
+		[389539] = {parent = 31884}, -- Sentinel
     [115750] = {duration = 90, class = "PALADIN"}, -- Blinding Light
     [375576] = {duration = 60, class = "PALADIN"}, -- Divine Toll
     [105809] = {duration = 90, class = "PALADIN"}, -- Holy Avenger
@@ -236,6 +235,7 @@ addon.Cooldowns = {
     [106839] = {default = true, duration = 15, class = "DRUID"}, -- Skull Bash
     [99] = {duration = 30, class = "DRUID"}, -- Incapacitating Roar
     [102793] = {duration = 60, class = "DRUID"}, -- Ursol's Vortex
+    [124974] = {duration = 90, class = "DRUID"}, -- Nature's Vigil
 
 		-- Balance
 
@@ -246,6 +246,7 @@ addon.Cooldowns = {
 		[202770] = {duration = 60, class = "DRUID", specID = {102}}, -- Fury of Elune
 		[205636] = {duration = 60, class = "DRUID", specID = {102}}, -- Force of Nature
 		[209749] = {duration = 30, class = "DRUID", specID = {102}}, -- Faerie Swarm
+		[202359] = {duration = 60, class = "DRUID", specID = {102}}, -- Astral Communion
 		[2782] = {duration = 8, class = "DRUID", specID = {102, 103, 104}}, -- Remove Corruption
 
 		-- Feral
@@ -256,6 +257,7 @@ addon.Cooldowns = {
 		[106898] = {duration = 120, class = "DRUID", specID = {103, 104}}, -- Stampeding Roar
 		[106951] = {duration = 180, class = "DRUID", specID = {103}}, -- Berserk
 		[274837] = {duration = 45, class = "DRUID", specID = {103}}, -- Feral Frenzy
+		[391888] = {duration = 25, class = "DRUID", specID = {103, 105}}, -- Adaptive Swarm
 
 		-- Guardian
 
@@ -279,24 +281,24 @@ addon.Cooldowns = {
 		[88423] = {duration = 8, class = "DRUID", specID = {105}}, -- Nature's Cure
 		[132158] = {duration = 60, class = "DRUID", specID = {105}}, -- Nature's Swiftness
 
-	-- Warrior
+    -- Warrior
 
-	[100] = {duration = 17, class = "WARRIOR", charges = 2}, -- Charge
-	[3411] = {duration = 30, class = "WARRIOR"}, -- Intervene
-	[6544] = {duration = 30, class = "WARRIOR", charges = 2}, -- Heroic Leap
-	[6552] = {default = true, duration = 15, class = "WARRIOR"}, -- Pummel
-	[18499] = {duration = 60, class = "WARRIOR"}, -- Berserker Rage
+    [100] = {duration = 17, class = "WARRIOR", charges = 2}, -- Charge
+    [3411] = {duration = 30, class = "WARRIOR"}, -- Intervene
+    [6544] = {duration = 30, class = "WARRIOR", charges = 2}, -- Heroic Leap
+    [6552] = {default = true, duration = 14, class = "WARRIOR"}, -- Pummel
+    [18499] = {duration = 60, class = "WARRIOR"}, -- Berserker Rage
 		[384100] = {parent = 18499, duration = 60}, -- Berserker Shout
-	[23920] = {duration = 25, class = "WARRIOR"}, -- Spell Reflection
-	[46968] = {duration = 40, class = "WARRIOR"}, -- Shockwave
-	[107570] = {duration = 30, class = "WARRIOR"}, -- Storm Bolt
-	[107574] = {duration = 90, class = "WARRIOR"}, -- Avatar
-	[236077] = {duration = 45, class = "WARRIOR"}, -- Disarm
-	[376079] = {duration = 90, class = "WARRIOR"}, -- Spear of Bastion
-	[5246] = {duration = 90, class = "WARRIOR"}, -- Intimidating Shout
-	[97462] = {duration = 180, class = "WARRIOR"}, -- Rallying Cry
-	[386208] = {duration = 3, class = "WARRIOR"}, -- Defensive Stance
-	[384318] = {duration = 90, class = "WARRIOR"}, -- Thunderous Roar
+    [23920] = {duration = 25, class = "WARRIOR"}, -- Spell Reflection
+    [46968] = {duration = 40, class = "WARRIOR"}, -- Shockwave
+    [107570] = {duration = 30, class = "WARRIOR"}, -- Storm Bolt
+    [107574] = {duration = 90, class = "WARRIOR"}, -- Avatar
+    [236077] = {duration = 45, class = "WARRIOR"}, -- Disarm
+    [376079] = {duration = 90, class = "WARRIOR"}, -- Spear of Bastion
+    [5246] = {duration = 90, class = "WARRIOR"}, -- Intimidating Shout
+    [97462] = {duration = 180, class = "WARRIOR"}, -- Rallying Cry
+    [386208] = {duration = 3, class = "WARRIOR"}, -- Defensive Stance
+    [384318] = {duration = 90, class = "WARRIOR"}, -- Thunderous Roar
 
 		-- Arms
 
@@ -358,7 +360,6 @@ addon.Cooldowns = {
     [333889] = {duration = 120, class = "WARLOCK"}, -- Fel Domination
     [328774] = {duration = 20, class = "WARLOCK"}, -- Amplify Curse
     [212623] = {duration = 15, class = "WARLOCK"}, -- Singe Magic
-		[137178] = {parent = 212623}, -- Singe Magic
 		[89808] = {parent = 212623}, -- Singe Magic
 		[119905] = {parent = 212623}, -- Singe Magic
 
@@ -388,7 +389,7 @@ addon.Cooldowns = {
 		[264130] = {duration = 30, class = "WARLOCK", specID = {266}}, -- Power Siphon
 		[264119] = {duration = 45, class = "WARLOCK", specID = {266}}, -- Summon Vilefiend
 
-		--  Destruction
+		-- Destruction
 
 		[17962] = {duration = 12, class = "WARLOCK", specID = {267}, charges = 2}, -- Conflagrate
 		[80240] = {duration = 30, class = "WARLOCK", specID = {267}}, -- Havoc
@@ -510,6 +511,7 @@ addon.Cooldowns = {
 		[359844] = {duration = 180, class = "HUNTER", specID = {253}}, -- Call of the Wild
 		[205691] = {duration = 120, class = "HUNTER", specID = {253}}, -- Dire Beast: Basilisk
 		[356707] = {duration = 60, class = "HUNTER", specID = {253}}, -- Wild Kingdom
+		[321530] = {duration = 60, class = "HUNTER", specID = {253}}, -- Bloodshed
 
 		-- Marksmanship
 
@@ -567,6 +569,8 @@ addon.Cooldowns = {
 		[30449] = {duration = 30, class = "MAGE", specID = {62}}, -- Spellsteal (Kleptomania)
 		[198111] = {duration = 45, class = "MAGE", specID = {62}}, -- Temporal Shield
 		[353128] = {duration = 45, class = "MAGE", specID = {62}}, -- Arcanosphere
+		[376103] = {duration = 30, class = "MAGE", specID = {62}}, -- Radiant Spark
+		[321507] = {duration = 45, class = "MAGE", specID = {62}}, -- Touch of the Magi
 
 		-- Fire
 


### PR DESCRIPTION
Edited
- Mighty Ox Kick fixed to 30s CD
- Fade to 20s CD
- Amplify Curse to 20s CD
- Pummel to 14s CD

Added
- Consume Magic
- Lichborne
- Soul Fire
- Nature's Vigil
- Astral Communion
- Adaptive Swarm
- Radiant Spark
- Touch of the Magi
- Bloodshed
- Flanking Strike