### PR TITLE
10.1 Spell Updates

### DIFF
--- a/OmniBar_Mainline.lua
+++ b/OmniBar_Mainline.lua
@@ -371,6 +371,7 @@ addon.Cooldowns = {
     [328774] = {duration = 20, class = "WARLOCK"}, -- Amplify Curse
     [410598] = {duration = 60, class = "WARLOCK"}, -- Soul Rip
     [201996] = {duration = 60, class = "WARLOCK"}, -- Call Observer
+    [353753] = {duration = 30, class = "WARLOCK"}, -- Bonds of Fel
     [212623] = {duration = 15, class = "WARLOCK"}, -- Singe Magic
 		[89808] = {parent = 212623}, -- Singe Magic
 		[119905] = {parent = 212623}, -- Singe Magic

--- a/OmniBar_Mainline.lua
+++ b/OmniBar_Mainline.lua
@@ -70,6 +70,7 @@ addon.Cooldowns = {
 		[207289] = {duration = 90, class = "DEATHKNIGHT", specID = {252}}, -- Unholy Assault
 		[275699] = {duration = 45, class = "DEATHKNIGHT", specID = {252}}, -- Apocalypse
 		[390279] = {duration = 90, class = "DEATHKNIGHT", specID = {252}}, -- Vile Contagion
+	        [210128] = {duration = 12, class = "DEATHKNIGHT", specID = {252}, charges = 2}, -- Reanimation
 		[115989] = {duration = 45, class = "DEATHKNIGHT", specID = {252}}, -- Unholy Blight
 
     -- Demon Hunter
@@ -116,7 +117,7 @@ addon.Cooldowns = {
     [32375] = {duration = 45, class = "PRIEST"}, -- Mass Dispel
     [375901] = {duration = 45, class = "PRIEST"}, -- Mindgames
     [316262] = {duration = 90, class = "PRIEST"}, -- Thoughtsteal
-    [32379] = {duration = 20, class = "PRIEST"}, -- Shadow Word: Death
+    [32379] = {duration = 10, class = "PRIEST"}, -- Shadow Word: Death
     [10060] = {duration = 120, class = "PRIEST"}, -- Power Infusion
     [8122] = {duration = 30, class = "PRIEST"}, -- Psychic Scream
     [73325] = {duration = 90, class = "PRIEST"}, -- Leap of Faith
@@ -133,7 +134,7 @@ addon.Cooldowns = {
 			[123040] = {parent = 34433, duration = 60}, -- Mindbender (Discipline)
 			[200174] = {parent = 34433, duration = 60}, -- Mindbender (Shadow)
 		[47536] = {duration = 90, class = "PRIEST", specID = {256}}, -- Rapture
-		[62618] = {duration = 90, class = "PRIEST", specID = {256}}, -- Power Word: Barrier
+		[62618] = {duration = 180, class = "PRIEST", specID = {256}}, -- Power Word: Barrier
 		[197862] = {duration = 60, class = "PRIEST", specID = {256}}, -- Archangel
 		[197871] = {duration = 60, class = "PRIEST", specID = {256}}, -- Dark Archangel
 		[314867] = {duration = 30, class = "PRIEST", specID = {256}}, -- Shadow Covenant
@@ -159,10 +160,10 @@ addon.Cooldowns = {
 		[15487] = {duration = 45, class = "PRIEST", specID = {258}}, -- Silence
 		[47585] = {duration = 90, class = "PRIEST", specID = {258}}, -- Dispersion
 		[64044] = {duration = 45, class = "PRIEST", specID = {258}}, -- Psychic Horror
-		[263165] = {duration = 60, class = "PRIEST", specID = {258}}, -- Void Torrent
+		[263165] = {duration = 45, class = "PRIEST", specID = {258}}, -- Void Torrent
 		[205369] = {duration = 30, class = "PRIEST", specID = {258}}, -- Mind Bomb
 		[211522] = {duration = 45, class = "PRIEST", specID = {258}}, -- Psyfiend
-		[341374] = {duration = 60, class = "PRIEST", specID = {258}}, -- Damnation
+		[205385] = {duration = 20, class = "PRIEST", specID = {258}}, -- Shadow Crash
 		[228260] = {duration = 120, class = "PRIEST", specID = {258}}, -- Void Form
 		[391109] = {duration = 60, class = "PRIEST", specID = {258}}, -- Dark Ascension
 		[213634] = {duration = 8, class = "PRIEST", specID = {258}}, -- Purify Disease
@@ -186,6 +187,7 @@ addon.Cooldowns = {
     [105809] = {duration = 90, class = "PALADIN"}, -- Holy Avenger
     [96231] = {default = true, duration = 15, class = "PALADIN"}, -- Rebuke
     [190784] = {duration = 45, class = "PALADIN", charges = 2}, -- Divine Steed
+    [410126] = {duration = 60, class = "PALADIN"}, -- Searing Glare
 
 		-- Holy
 
@@ -360,15 +362,15 @@ addon.Cooldowns = {
 		[171138] = {parent = 119910}, -- Shadow Lock (Doomguard)
 		[171139] = {parent = 119910}, -- Shadow Lock (Grimoire of Sacrifice)
 		[171140] = {parent = 119910}, -- Shadow Lock (Command Demon)
-    [199954] = {duration = 45, class = "WARLOCK"}, -- Bane of Fragility
     [212295] = {duration = 45, class = "WARLOCK"}, -- Nether Ward
-    [221703] = {duration = 60, class = "WARLOCK"}, -- Casting Circle
     [5484] = {duration = 40, class = "WARLOCK"}, -- Howl of Terror
     [384069] = {duration = 15, class = "WARLOCK"}, -- Shadowflame
     [353294] = {duration = 60, class = "WARLOCK"}, -- Shadow Rift
     [48020] = {duration = 30, class = "WARLOCK"}, -- Demonic Circle Teleport
     [333889] = {duration = 120, class = "WARLOCK"}, -- Fel Domination
     [328774] = {duration = 20, class = "WARLOCK"}, -- Amplify Curse
+    [410598] = {duration = 60, class = "WARLOCK"}, -- Soul Rip
+    [201996] = {duration = 60, class = "WARLOCK"}, -- Call Observer
     [212623] = {duration = 15, class = "WARLOCK"}, -- Singe Magic
 		[89808] = {parent = 212623}, -- Singe Magic
 		[119905] = {parent = 212623}, -- Singe Magic
@@ -387,7 +389,6 @@ addon.Cooldowns = {
 		[89751] = {duration = 30, class = "WARLOCK", specID = {266}}, -- Felstorm
 			[115831] = {parent = 89751}, -- Wrathstorm
 		[89766] = {duration = 30, class = "WARLOCK", specID = {266}}, -- Axe Toss
-		[201996] = {duration = 90, class = "WARLOCK", specID = {266}}, -- Call Observer
 		[265187] = {duration = 90, class = "WARLOCK", specID = {266}}, -- Summon Demonic Tyrant
 		[212459] = {duration = 120, class = "WARLOCK", specID = {266}}, -- Call Fel Lord
 		[212619] = {default = true, duration = 60, class = "WARLOCK", specID = {266}}, -- Call Felhunter
@@ -413,7 +414,7 @@ addon.Cooldowns = {
     -- Shaman
 
     [20608] = {duration = 1800, class = "SHAMAN"}, -- Reincarnation
-    [51485] = {duration = 54, class = "SHAMAN"}, -- Earthgrab Totem
+    [51485] = {duration = 24, class = "SHAMAN"}, -- Earthgrab Totem
     [51514] = {duration = {default = 30, [264] = 10}, class = "SHAMAN"}, -- Hex
 		[196932] = {parent = 51514}, -- Voodoo Totem
 		[210873] = {parent = 51514}, -- Hex (Compy)
@@ -446,6 +447,8 @@ addon.Cooldowns = {
     [383013] = {duration = 39, class = "SHAMAN"}, -- Poison Cleansing Totem
     [378773] = {duration = 12, class = "SHAMAN"}, -- Greater Purge
     [108285] = {duration = 180, class = "SHAMAN"}, -- Totemic Recall
+    [355580] = {duration = 54, class = "SHAMAN"}, -- Static Field Totem
+    [409293] = {duration = 120, class = "SHAMAN"}, -- Burrow
 
 		-- Elemental
 
@@ -461,14 +464,12 @@ addon.Cooldowns = {
 		-- Enhancement
 
 		[196884] = {duration = 30, class = "SHAMAN", specID = {263}}, -- Feral Lunge
-		[197214] = {duration = 40, class = "SHAMAN", specID = {263}}, -- Sundering
-		[204366] = {duration = 45, class = "SHAMAN", specID = {263}}, -- Thundercharge
+		[197214] = {duration = 40, class = "SHAMAN", specID = {263}}, -- Sundering		
 		[384352] = {duration = 90, class = "SHAMAN", specID = {263}}, -- Doom Winds
 		[51533] = {duration = 90, class = "SHAMAN", specID = {263}}, -- Feral Spirits
 		[204361] = {duration = 60, class = "SHAMAN", specID = {263}}, -- Bloodlust (Shamanism)
 			[204362] = {parent = 204361}, -- Heroism (Shamanism)
 		[114051] = {duration = 180, class = "SHAMAN", specID = {263}}, -- Ascendance (Enhancement)
-		[210918] = {duration = 60, class = "SHAMAN", specID = {263}}, -- Ethereal Form
 
 		-- Restoration
 
@@ -498,9 +499,8 @@ addon.Cooldowns = {
     [209997] = {duration = 30, class = "HUNTER"}, -- Play Dead
     [781] = {duration = 20, class = "HUNTER"}, -- Disengage
     [19577] = {duration = 60, class = "HUNTER"}, -- Intimidation
-    [109248] = {duration = 45, class = "HUNTER"}, -- Binding Shot
-    [248518] = {duration = 45, class = "HUNTER"}, -- Interlope
-    [34477] = {duration = 30, class = "HUNTER"}, -- Misdirection
+    [109248] = {duration = 45, class = "HUNTER"}, -- Binding Shot    
+    [34477] = {duration = 45, class = "HUNTER"}, -- Misdirection (Interlope)
     [199483] = {duration = 60, class = "HUNTER"}, -- Camouflage
     [213691] = {duration = 30, class = "HUNTER"}, -- Scatter Shot
     [53271] = {duration = 45, class = "HUNTER"}, -- Master's Call
@@ -543,6 +543,7 @@ addon.Cooldowns = {
 		[360966] = {duration = 90, class = "HUNTER", specID = {255}}, -- Spearhead
 		[269751] = {duration = 30, class = "HUNTER", specID = {255}}, -- Flanking Strike
 		[212638] = {duration = 25, class = "HUNTER", specID = {255}}, -- Tracker's Net
+	        [407028] = {duration = 45, class = "HUNTER", specID = {255}}, -- Sticky Tar Bomb
 
     -- Mage
 
@@ -681,7 +682,7 @@ addon.Cooldowns = {
 		[324312] = {duration = 30, class = "MONK", specID = {268}}, -- Clash
 		[202335] = {duration = 45, class = "MONK", specID = {268}}, -- Double Barrel
 		[325153] = {duration = 60, class = "MONK", specID = {268}}, -- Exploding Keg
-		[115176] = {duration = 56, class = "MONK", specID = {268}}, -- Zen Meditation
+		[115176] = {duration = 112, class = "MONK", specID = {268}}, -- Zen Meditation
 		[354540] = {duration = 90, class = "MONK", specID = {268}}, -- Nimble Brew
 		[218164] = {duration = 8, class = "MONK", specID = {268, 269}}, -- Detox
 		[386276] = {duration = 60, class = "MONK", specID = {268, 269}}, -- Bonedust Brew
@@ -733,14 +734,14 @@ addon.Cooldowns = {
     [357208] = {duration = 30, class = "EVOKER"}, -- Fire Breath
     [357210] = {duration = 60, class = "EVOKER"}, -- Deep Breath
     [383005] = {duration = 60, class = "EVOKER"}, -- Chrono Loop
-    [378441] = {duration = 120, class = "EVOKER"}, -- Time Stop
+    [378441] = {duration = 90, class = "EVOKER"}, -- Time Stop
     [370388] = {duration = 90, class = "EVOKER"}, -- Swoop Up
     [378464] = {duration = 90, class = "EVOKER"}, -- Nullifying Shroud
 
 		-- Devastation
 
 		[375087] = {duration = 120, class = "EVOKER", specID = {1467}}, -- Dragonrage
-		[370452] = {duration = 15, class = "EVOKER", specID = {1467}}, -- Shattering Star
+		[370452] = {duration = 20, class = "EVOKER", specID = {1467}}, -- Shattering Star
 		[368847] = {duration = 20, class = "EVOKER", specID = {1467}}, -- Firestorm
 		[359073] = {duration = 30, class = "EVOKER", specID = {1467}}, -- Eternity Surge
 		[365585] = {duration = 8, class = "EVOKER", specID = {1467}}, -- Expunge

--- a/OmniBar_Mainline.lua
+++ b/OmniBar_Mainline.lua
@@ -579,7 +579,7 @@ addon.Cooldowns = {
 		[157980] = {duration = 25, class = "MAGE", specID = {62}}, -- Supernova
 		[198158] = {duration = 60, class = "MAGE", specID = {62}}, -- Mass Invisibility
 		[205025] = {duration = 45, class = "MAGE", specID = {62}}, -- Presence of Mind
-		[30449] = {duration = 30, class = "MAGE", specID = {62}}, -- Spellsteal (Kleptomania)
+		[198100] = {duration = 20, class = "MAGE", specID = {62}}, -- Spellsteal (Kleptomania)
 		[198111] = {duration = 45, class = "MAGE", specID = {62}}, -- Temporal Shield
 		[353128] = {duration = 45, class = "MAGE", specID = {62}}, -- Arcanosphere
 		[376103] = {duration = 30, class = "MAGE", specID = {62}}, -- Radiant Spark


### PR DESCRIPTION
- Added Reanimation (Unholy DK PvP Talent redesign)
- Added Shadow Crash to replace Damnation being removed
- Added Searing Glare (new Paladin Class PvP Talent)
- Added Soul Rip (new Warlock Class PvP Talent)
- Added Bonds of Fel (Warlock PvP Talent)
- Added Burrow (new Shaman Class PvP Talent)
- Added Sticky Tar Bomb (new Survival Hunter PvP Talent)
### 
- Edited CD of Shadow Word: Death, Power Word: Barrier, and Void Torrent for Priests
- Edited Call Observer from Demonology Warlock only to all 3 specs and reduced CD
- Edited Earthgrab CD for Shamans
- Edited Static Field Totem to all Shaman specs
- Edited Interlope/Misdirection CDs
- Edited CD of Zen Meditation for Brewmaster Monks
- Edited CD of Time Stomp for Evokers
- Edited CD of Shattering Star for Devastation Evokers
- Edited CD/Spell ID of Kleptomania redesign for Arcane Mages
### 
- Removed Damnation, Bane of Fragility, Casting Circle, Thundercharge, Ethereal Form