### PR TITLE
10.1.7 Patch Update

### DIFF
--- a/OmniBar_Mainline.lua
+++ b/OmniBar_Mainline.lua
@@ -53,7 +53,7 @@ addon.Cooldowns = {
 
 		[51271] = {duration = 60, class = "DEATHKNIGHT", specID = {251}}, -- Pillar of Frost
 		[152279] = {duration = 120, class = "DEATHKNIGHT", specID = {251}}, -- Breath of Sindragosa
-		[196770] = {duration = 20, class = "DEATHKNIGHT", specID = {251}}, -- Remorseless Winter
+		[196770] = {duration = 30, class = "DEATHKNIGHT", specID = {251}}, -- Remorseless Winter
 		[305392] = {duration = 45, class = "DEATHKNIGHT", specID = {251}}, -- Chill Streak
 		[279302] = {duration = 90, class = "DEATHKNIGHT", specID = {251}}, -- Frostwyrm's Fury
 
@@ -120,7 +120,7 @@ addon.Cooldowns = {
     [10060] = {duration = 120, class = "PRIEST"}, -- Power Infusion
     [8122] = {duration = 30, class = "PRIEST"}, -- Psychic Scream
     [73325] = {duration = 60, class = "PRIEST"}, -- Leap of Faith
-    [19236] = {duration = 90, class = "PRIEST"}, -- Desperate Prayer
+    [19236] = {duration = 70, class = "PRIEST"}, -- Desperate Prayer
     [108920] = {duration = 60, class = "PRIEST"}, -- Void Tendrils
     [108968] = {duration = 300, class = "PRIEST"}, -- Void Shift
     [373481] = {duration = 30, class = "PRIEST"}, -- Power Word: Life
@@ -707,12 +707,11 @@ addon.Cooldowns = {
 			[388615] = {parent = 115310, duration = 90}, -- Restoral
 		[116680] = {duration = 30, class = "MONK", specID = {270}}, -- Thunder Focus Tea
 		[116849] = {duration = 75, class = "MONK", specID = {270}}, -- Life Cocoon
-		[197908] = {duration = 90, class = "MONK", specID = {270}}, -- Mana Tea
 		[198898] = {duration = 30, class = "MONK", specID = {270}}, -- Song of Chi-Ji
 		[205234] = {duration = 15, class = "MONK", specID = {270}, charges = 3}, -- Healing Sphere
 		[388193] = {duration = 30, class = "MONK", specID = {269, 270}}, -- Faeline Stomp
 		[322118] = {duration = 180, class = "MONK", specID = {270}}, -- Invoke Yu'Lon, the Jade Serpent
-			[325197] = {parent = 322118, duration = 60}, -- Invoke Chi-Ji, the Red Crane
+		[325197] = {duration = 60, class = "MONK", specID = {270}}, -- Invoke Chi-Ji, the Red Crane
 		[122281] = {duration = 30, class = "MONK", specID = {268, 270}, charges = 2}, -- Healing Elixir
 		[115450] = {duration = 8, class = "MONK", specID = {270}}, -- Detox
 
@@ -723,7 +722,7 @@ addon.Cooldowns = {
     [360995] = {duration = 16, class = "EVOKER"}, -- Verdant Embrace
     [357214] = {duration = 90, class = "EVOKER"}, -- Wing Buffet
     [368970] = {duration = 90, class = "EVOKER"}, -- Tail Swipe
-    [351338] = {default = true, duration = {default = 40, [1467] = 20, [1473] = 20}, class = "EVOKER"}, -- Quell
+    [351338] = {default = true, duration = {default = 20, [1468] = 40}, class = "EVOKER"}, -- Quell
     [374251] = {duration = 60, class = "EVOKER"}, -- Cauterizing Flame
     [360806] = {duration = 15, class = "EVOKER"}, -- Sleep Walk
     [370553] = {duration = 120, class = "EVOKER"}, -- Tip the Scales

--- a/OmniBar_Mainline.lua
+++ b/OmniBar_Mainline.lua
@@ -238,6 +238,8 @@ addon.Cooldowns = {
     [22570] = {duration = 20, class = "DRUID"}, -- Maim
     [106839] = {default = true, duration = 15, class = "DRUID"}, -- Skull Bash
     [99] = {duration = 30, class = "DRUID"}, -- Incapacitating Roar
+    [106898] = {duration = 60, class = "DRUID"}, -- Stampeding Roar
+		[77761] = {parent = 106898, duration = 60}, -- Stampeding Roar
     [102793] = {duration = 60, class = "DRUID"}, -- Ursol's Vortex
     [124974] = {duration = 90, class = "DRUID"}, -- Nature's Vigil
 
@@ -260,7 +262,6 @@ addon.Cooldowns = {
 		[5217] = {duration = 30, class = "DRUID", specID = {103}}, -- Tiger's Fury
 		[61336] = {duration = {default = 180, [104] = 120}, class = "DRUID", specID = {103, 104}, charges = 2}, -- Survival Instincts
 		[102543] = {duration = 180, class = "DRUID", specID = {103}}, -- Incarnation: Avatar of Ashamane
-		[106898] = {duration = 120, class = "DRUID", specID = {103, 104}}, -- Stampeding Roar
 		[106951] = {duration = 180, class = "DRUID", specID = {103}}, -- Berserk
 		[274837] = {duration = 45, class = "DRUID", specID = {103}}, -- Feral Frenzy
 		[391888] = {duration = 25, class = "DRUID", specID = {103, 105}}, -- Adaptive Swarm
@@ -289,6 +290,7 @@ addon.Cooldowns = {
 		[392160] = {duration = 20, class = "DRUID", specID = {105}}, -- Invigorate
 		[305497] = {duration = 45, class = "DRUID", specID = {102, 103, 105}}, -- Thorns
 		[88423] = {duration = 8, class = "DRUID", specID = {105}}, -- Nature's Cure
+	        [102693] = {duration = 20, class = "DRUID", specID = {105}, charges = 3}, -- Grove Guardians
 		[132158] = {duration = 60, class = "DRUID", specID = {105}}, -- Nature's Swiftness
 
     -- Warrior


### PR DESCRIPTION
TOC :  100107

Added:

- Grove Guardians (Restoration Druid)

Edited:

- Remorseless Winter CD (Frost Death Knight), Desperate Prayer CD (Priest), Stampeding Roar (All Druid specializations now and both IDs for forms), removed Invoke Chi-Ji, the Red Crane as a child (Mistweaver Monk), and changed default Evoker Quell ID.

Removed:

- Mana Tea (Mistweaver Monk)