### PR TITLE
11.0.5 Changes

### DIFF
--- a/OmniBar_Mainline.lua
+++ b/OmniBar_Mainline.lua
@@ -34,8 +34,8 @@ addon.Cooldowns = {
     [383269] = {duration = 120, class = "DEATHKNIGHT"}, -- Abomination's Limb
     [48743] = {duration = 120, class = "DEATHKNIGHT"}, -- Death Pact
     [439843] = {duration = 30, class = "DEATHKNIGHT", specID = {250, 251}}, -- Reaper's Mark
-    [43265] = {duration = 30, class = "DEATHKNIGHT", charges = 2}, -- Death and Decay
-		[152280] = {parent = 43265, duration = 20, specID = {252}}, -- Defile
+    [43265] = {duration = 20, class = "DEATHKNIGHT", charges = 2}, -- Death and Decay
+		[152280] = {parent = 43265, duration = 15, specID = {252}}, -- Defile
     [49039] = {duration = 120, class = "DEATHKNIGHT"}, -- Lichborne
 
 		-- Blood
@@ -179,14 +179,14 @@ addon.Cooldowns = {
 
     [633] = {duration = 420, class = "PALADIN"}, -- Lay on Hands
     [642] = {duration = 210, class = "PALADIN"}, -- Divine Shield
-    [853] = {duration = 60, class = "PALADIN"}, -- Hammer of Justice
+    [853] = {duration = 30, class = "PALADIN"}, -- Hammer of Justice
     [1022] = {duration = 240, class = "PALADIN", charges = 2}, -- Blessing of Protection
     [1044] = {duration = 25, class = "PALADIN", charges = 2}, -- Blessing of Freedom
     [6940] = {duration = 60, class = "PALADIN"}, -- Blessing of Sacrifice
 		[199448] = {parent = 6940, duration = 60}, -- Ultimate Sacrifice
     [20066] = {duration = 15, class = "PALADIN"}, -- Repentance
     [31884] = {duration = 120, class = "PALADIN"}, -- Avenging Wrath
-    [115750] = {duration = 90, class = "PALADIN"}, -- Blinding Light
+    [115750] = {duration = 75, class = "PALADIN"}, -- Blinding Light
     [375576] = {duration = 60, class = "PALADIN"}, -- Divine Toll
     [96231] = {default = true, duration = 15, class = "PALADIN"}, -- Rebuke
     [190784] = {duration = 45, class = "PALADIN", charges = 2}, -- Divine Steed
@@ -253,9 +253,9 @@ addon.Cooldowns = {
 
 		[78675] = {default = true, duration = 60, class = "DRUID", specID = {102}}, -- Solar Beam
 		[390414] = {duration = 120, class = "DRUID", specID = {102}}, -- Incarnation: Chosen of Elune (Orbital Strike)
-			[102560] = {parent = 102560, duration = 180}, -- Incarnation: Chosen of Elune
+			[102560] = {parent = 390414, duration = 90, charges = 2}, -- Incarnation: Chosen of Elune
 		[383410] = {duration = 120, class = "DRUID", specID = {102}}, -- Celestial Alignment (Orbital Strike)
-			[194223] = {parent = 194223, duration = 180}, -- Celestial Alignment
+			[194223] = {parent = 383410, duration = 90, charges = 2}, -- Celestial Alignment
 		[202425] = {duration = 45, class = "DRUID", specID = {102}}, -- Warrior of Elune
 		[202770] = {duration = 45, class = "DRUID", specID = {102}}, -- Fury of Elune
 		[205636] = {duration = 45, class = "DRUID", specID = {102}}, -- Force of Nature
@@ -267,7 +267,7 @@ addon.Cooldowns = {
 		[5217] = {duration = 30, class = "DRUID", specID = {103}}, -- Tiger's Fury
 		[61336] = {duration = {default = 180, [104] = 120}, class = "DRUID", specID = {103, 104}, charges = 2}, -- Survival Instincts
 		[102543] = {duration = 120, class = "DRUID", specID = {103}}, -- Incarnation: Avatar of Ashamane
-		[106951] = {duration = 120, class = "DRUID", specID = {103}}, -- Berserk
+			[106951] = {parent = 102543}, -- Berserk
 		[274837] = {duration = 45, class = "DRUID", specID = {103}}, -- Feral Frenzy
 		[391888] = {duration = 25, class = "DRUID", specID = {103}}, -- Adaptive Swarm
 
@@ -289,14 +289,14 @@ addon.Cooldowns = {
 		[18562] = {duration = 15, class = "DRUID", specID = {105}, charges = 2}, -- Swiftmend
 		[33891] = {duration = 180, class = "DRUID", specID = {105}}, -- Incarnation: Tree of Life
 		[102342] = {duration = 90, class = "DRUID", specID = {105}}, -- Ironbark
-		[102351] = {duration = 30, class = "DRUID", specID = {105}}, -- Cenarion Ward
+		[102351] = {duration = 20, class = "DRUID", specID = {105}}, -- Cenarion Ward
 		[197721] = {duration = 60, class = "DRUID", specID = {105}}, -- Flourish
 		[203651] = {duration = 60, class = "DRUID", specID = {105}}, -- Overgrowth
 		[392160] = {duration = 20, class = "DRUID", specID = {105}}, -- Invigorate
 		[305497] = {duration = 45, class = "DRUID", specID = {102, 103, 105}}, -- Thorns
 		[88423] = {duration = 8, class = "DRUID", specID = {105}}, -- Nature's Cure
 	        [102693] = {duration = 20, class = "DRUID", specID = {105}, charges = 3}, -- Grove Guardians
-		[132158] = {duration = 60, class = "DRUID", specID = {105}}, -- Nature's Swiftness
+		[132158] = {duration = 60, class = "DRUID", specID = {105}, charges = 2}, -- Nature's Swiftness
 
     -- Warrior
 
@@ -451,7 +451,7 @@ addon.Cooldowns = {
     [204336] = {duration = 24, class = "SHAMAN"}, -- Grounding Totem
     [356736] = {duration = 30, class = "SHAMAN"}, -- Unleash Shield
     [108270] = {duration = 174, class = "SHAMAN"}, -- Stone Bulwark Totem
-    [383013] = {duration = 39, class = "SHAMAN"}, -- Poison Cleansing Totem
+    [383013] = {duration = 114, class = "SHAMAN"}, -- Poison Cleansing Totem
     [378773] = {duration = 12, class = "SHAMAN"}, -- Greater Purge
     [108285] = {duration = 180, class = "SHAMAN"}, -- Totemic Recall
     [355580] = {duration = 84, class = "SHAMAN"}, -- Static Field Totem
@@ -468,7 +468,7 @@ addon.Cooldowns = {
 		[191634] = {duration = 60, class = "SHAMAN", specID = {262}, charges = 2}, -- Stormkeeper
 		[117014] = {duration = 12, class = "SHAMAN", specID = {262, 263}}, -- Elemental Blast
 		[51886] = {duration = 8, class = "SHAMAN", specID = {262, 263}}, -- Cleanse Spirit
-		[114050] = {duration = 120, class = "SHAMAN", specID = {262}}, -- Ascendance (Elemental)
+		[114050] = {duration = 180, class = "SHAMAN", specID = {262}}, -- Ascendance (Elemental)
 
 		-- Enhancement
 
@@ -478,7 +478,7 @@ addon.Cooldowns = {
 		[51533] = {duration = 90, class = "SHAMAN", specID = {263}}, -- Feral Spirits
 		[204361] = {duration = 60, class = "SHAMAN", specID = {262,263}}, -- Bloodlust (Shamanism)
 			[204362] = {parent = 204361}, -- Heroism (Shamanism)
-		[114051] = {duration = 180, class = "SHAMAN", specID = {263}}, -- Ascendance (Enhancement)
+		[114051] = {duration = 120, class = "SHAMAN", specID = {263}}, -- Ascendance (Enhancement)
 
 		-- Restoration
 
@@ -575,6 +575,7 @@ addon.Cooldowns = {
     [342245] = {duration = 50, class = "MAGE"}, -- Alter Time
     [475] = {duration = 8, class = "MAGE"}, -- Remove Curse
     [157980] = {duration = 45, class = "MAGE"}, -- Supernova
+		[449700] = {parent = 157980, duration = 40}, -- Gravity Lapse
     [414660] = {duration = 180, class = "MAGE"}, -- Mass Barrier
     [383121] = {duration = 60, class = "MAGE"}, -- Mass Polymorph
     [414664] = {duration = 60, class = "MAGE"}, -- Mass Invisibility
@@ -624,7 +625,6 @@ addon.Cooldowns = {
     [5938] = {duration = 30, class = "ROGUE", charges = 2}, -- Shiv
     [207777] = {duration = 45, class = "ROGUE"}, -- Dismantle
     [381623] = {duration = 60, class = "ROGUE", specID = {63}, charges = 3}, -- Thistle Tea
-    [385616] = {duration = 45, class = "ROGUE"}, -- Echoing Reprimand
     [1776] = {duration = 25, class = "ROGUE"}, -- Gouge
     [2094] = {duration = {default = 120, [260] = 90}, class = "ROGUE"}, -- Blind
     [212182] = {duration = 180, class = "ROGUE", specID = {259, 260}}, -- Smoke Bomb
@@ -642,18 +642,17 @@ addon.Cooldowns = {
 
 		[13750] = {duration = 180, class = "ROGUE", specID = {260}}, -- Adrenaline Rush
 		[51690] = {duration = 90, class = "ROGUE", specID = {260}}, -- Killing Spree
-		[195457] = {duration = 30, class = "ROGUE", specID = {260}}, -- Grappling Hook
+		[195457] = {duration = 30, class = "ROGUE", specID = {260}, charges = 2}, -- Grappling Hook
 		[315341] = {duration = 45, class = "ROGUE", specID = {260}}, -- Between the Eyes
 		[196937] = {duration = 90, class = "ROGUE", specID = {260}}, -- Ghostly Strike
 		[271877] = {duration = 45, class = "ROGUE", specID = {260}}, -- Blade Rush
 
 		-- Subtlety
 
-		[121471] = {duration = 120, class = "ROGUE", specID = {261}}, -- Shadow Blades
+		[121471] = {duration = 90, class = "ROGUE", specID = {261}}, -- Shadow Blades
 	        [185313] = {duration = 50, class = "ROGUE", charges = 2}, -- Shadow Dance
 		[207736] = {duration = 120, class = "ROGUE", specID = {261}}, -- Shadowy Duel
 		[384631] = {duration = 90, class = "ROGUE", specID = {261}}, -- Flagellation
-	        [385408] = {duration = 90, class = "ROGUE"}, -- Sepsis
 		[280719] = {duration = 45, class = "ROGUE", specID = {261}}, -- Secret Technique
 	        [426591] = {duration = 45, class = "ROGUE", specID = {261}}, -- Goremaw's Bite
 	        [212283] = {duration = 25, class = "ROGUE", specID = {261}}, -- Symbols of Death
@@ -717,8 +716,8 @@ addon.Cooldowns = {
     [363916] = {duration = 90, class = "EVOKER", charges = 2}, -- Obsidian Scales
     [358385] = {duration = 60, class = "EVOKER"}, -- Landslide
     [360995] = {duration = 16, class = "EVOKER"}, -- Verdant Embrace
-    [357214] = {duration = 90, class = "EVOKER"}, -- Wing Buffet
-    [368970] = {duration = 90, class = "EVOKER"}, -- Tail Swipe
+    [357214] = {duration = 60, class = "EVOKER"}, -- Wing Buffet
+    [368970] = {duration = 180, class = "EVOKER"}, -- Tail Swipe
     [351338] = {default = true, duration = {default = 20, [1468] = 40}, class = "EVOKER"}, -- Quell
     [374251] = {duration = 60, class = "EVOKER"}, -- Cauterizing Flame
     [360806] = {duration = 15, class = "EVOKER"}, -- Sleep Walk


### PR DESCRIPTION
**Death Knight**

- Lowered CD of Death and Decay and Defile to be in sync with Hero talents

**Paladin**

- Hammer of Justice edited to 30s CD
- Blinding Light CD edited to 75s CD

**Druid**

- Incarnation: Chosen of Elune/Celestial Alignment edited to have 2 charges with 90s CD
- Cenarion Ward edited to 20s CD
- Nature's Swiftness edited to have 2 charges

**Shaman**

- Poison Cleansing Totem edited to 114s CD
- Elemental's Ascendance edited to 180s CD and Enhancement's to 120s CD

**Mage**

- Gravity Lapse added with Supernova ability

**Rogue**

- Echoing Reprimand removed
- Grappling Hook edited to have 2 charges
- Shadow Blades edited to 90s CD

**Evoker**

- Wing Buffet edited to 60s CD
- Tail Swipe edited to 180s CD